### PR TITLE
Port webapp docs to readme

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+yarn-debug.log*
+yarn-error.log*
+npm-debug.log*
+.eslintcache
+bundle.js
+bundle.js.map
+

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,34 @@
+# Web app
+
+We use a React app to visualize data on the web.
+
+## Set up
+
+We use Yarn to manage dependencies, so install it:
+https://yarnpkg.com/lang/en/docs/install/#debian-stable
+
+Now, use Yarn to install dependencies:
+
+    yarn install
+
+## Run locally
+
+Start dev server:
+
+    npm run start_web:dev
+
+**Tip:** bind to a different host by passing the `--host` flag:
+
+    npm run start_web:dev -- --host 0.0.0.0
+
+Visit http://127.0.0.1:8080/ in your browser to view the webapp.
+
+## Deploy
+
+Bundle assets:
+
+    yarn build:dev
+
+Serve assets:
+https://trello.com/c/LapPIUpM/24-deploy-static-assets
+


### PR DESCRIPTION
**1. Brief Summary of what this PR accomplishes (140 characters or less. If you find trouble describing what you are doing in this length, consider breaking the PR into multiple ones.)**

We have onboarding docs for the web app. For consistency w the web server's readme, copy the web app onboarding docs to a readme in this repo. In a follow-up change, we can reconcile the onboarding docs in the old repo.

**2. Link to Trello Ticket**

N/A

**3. More detailed description and other questions to address in code review**

* Copy over the gitignore from the old repo
* Document how to bind the dev server to 0.0.0.0
  (for developing on a cloud machine)

**4. Remember to tag reviewers!**

@tramstheman @bennettbuchanan @JessDF @EdwardVillasenor1992 
